### PR TITLE
One char change http -> https; PyPi only supports HTTPS now

### DIFF
--- a/ez_setup.py
+++ b/ez_setup.py
@@ -47,7 +47,7 @@ except ImportError:
         return os.spawnl(os.P_WAIT, sys.executable, *args) == 0
 
 DEFAULT_VERSION = "0.6.14"
-DEFAULT_URL = "http://pypi.python.org/packages/source/d/distribute/"
+DEFAULT_URL = "https://pypi.python.org/packages/source/d/distribute/"
 SETUPTOOLS_FAKED_VERSION = "0.6c11"
 
 SETUPTOOLS_PKG_INFO = """\


### PR DESCRIPTION
Currently `python ez_setup.py` fails with:

urllib2.HTTPError: HTTP Error 403: SSL is required

After this commit:
Downloading https://pypi.python.org/packages/source/d/distribute/distribute-0.6.14.tar.gz
Extracting in /var/folders/8k/ywnwxb6d5kd2gqjfdmmtfzkw0000gn/T/tmpYf2lHV
...

Here's the announcement: https://mail.python.org/pipermail/distutils-sig/2017-October/031712.html